### PR TITLE
Consume values in channel

### DIFF
--- a/src/transducer_tut/tran.clj
+++ b/src/transducer_tut/tran.clj
@@ -119,14 +119,20 @@
 
 
 ;; Space complexity
-(->> zero-to-nine
-     (map inc); <--- intermediate step adds O(n) space 
-     (filter odd?)); <--- O(2n) at this point
+(let [xs (doall  (map inc zero-to-nine)); <--- intermediate step adds O(n) space 
+      xs (filter odd? xs)]
+  (doall xs)); <--- O(2n) at this point
 
-; wherein transducers, always O(n) space no matter the intermediate steps.
+
+;lazy-seq: let realization section be c
+(->> zero-to-nine
+     (map inc); <--- intermediate step adds O(c) space 
+     (filter odd?)); <--- O(2c) at this point
+
+; wherein transducers, always O(c) space no matter the intermediate steps.
 (sequence (comp (map inc)
                  (filter odd?))
-           zero-to-nine)
+           zero-to-nine); <--- on realization c, this will be O(c)
 
 
 ;; Make your own reducible/transducibles

--- a/src/transducer_tut/tran.clj
+++ b/src/transducer_tut/tran.clj
@@ -204,5 +204,8 @@
 
 (comment
   (-main)
+  (a/go-loop []
+    (let [x (a/<! some-external-input)])
+    (recur))
   )
 


### PR DESCRIPTION
The `some-external-input` channel only has a buffer of 1, so whenever we type _one_ thing on the text box, the `handler` function would block the UI. Executing the `go-loop` will consume from the channel indefinitely.

As an aside, the note is being played on the transducer, but perhaps it makes more sense that it gets played in the `go-loop` block as it feels like a side effect. Such that you're "pushing" notes onto the channel and playing the notes when "pulled".